### PR TITLE
Refactoring a conditional into a more neat form

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ poetry run invoke qtgen
 ```
 
 
+
 ### Backlog
 https://docs.google.com/spreadsheets/d/1r9CDM0Wv7Pt1SwhfaGoQBJD6Y9coEpHTB04byvhgGoU/edit#gid=1
 

--- a/src/gui/models/tip_model.py
+++ b/src/gui/models/tip_model.py
@@ -33,6 +33,6 @@ class TipModel(QAbstractListModel):
             row = index.row()
             s = ""
             for k, v in self.__tips[row].items():
-                if v != "":
+                if v:
                     s += f"{k}: {v}\n"
             return s


### PR DESCRIPTION
The conditional `if v != "":` can be simplified to `if v:` because an empty string is evaluated as `False`